### PR TITLE
Deleted OSA dependency onitself and /<dependency>

### DIFF
--- a/FermatManifest.xml
+++ b/FermatManifest.xml
@@ -448,12 +448,7 @@
 		</platform>
 
 		<platform code="PIP" name="Plug-ins Platform" logo="PIP_logo.png" dependsOn="P2P, COR">
-
-			<dependencies>
-				<dependency code="COR"></dependency>
-				<dependency code="OSA"></dependency>
-			</dependencies>
-
+			
 			<layer name="Sub App" language="java-android">
 				<androids>
 					<android
@@ -6585,7 +6580,7 @@
 
 		</super_layer>
 
-		<super_layer code="OSA" name="Operating System API" dependsOn="OSA">
+		<super_layer code="OSA" name="Operating System API">
 
 			<layer name="Multi OS" language="java">
 				<addons>


### PR DESCRIPTION
A group can't depend on itself. And there must be at least one independent group.

(This branch can be safely deleted after merge)
